### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/forketyfork/99-haskell-problems/security/code-scanning/1](https://github.com/forketyfork/99-haskell-problems/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to the least privilege required. Since the workflow only checks out code and runs tests and style checks, it does not require any write permissions. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file (just after the `name:` line and before `on:`), which will apply to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
